### PR TITLE
feat : 랜딩페이지 추가

### DIFF
--- a/src/components/nav/Footer.js
+++ b/src/components/nav/Footer.js
@@ -1,0 +1,36 @@
+import { Box, Container, Grid, Typography } from '@mui/material';
+
+const Footer = () => {
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '50vh',
+        backgroundColor: '#6b6b6b',
+      }}
+    >
+      <Container
+        maxWidth='lg'
+        sx={{
+          height: '100%',
+          justifyContent: 'center',
+        }}
+      >
+        <Grid container direction='column' alignItems='center' justifyContent="space-between">
+          <Grid item xs={12}>
+            <Typography color='black' variant='h2'>
+              Match.GG
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <Typography color='textSecondary' variant='subtitle1'>
+              {`${new Date().getFullYear()} | React | Material UI | React Router`}
+            </Typography>
+          </Grid>
+        </Grid>
+      </Container>
+    </Box>
+  );
+};
+
+export default Footer;

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import {
+  AppBar,
+  Stack,
+  Toolbar,
+  Typography,
+  Button,
+  Container,
+} from '@mui/material';
+
+const Navbar = () => {
+  return (
+    <AppBar
+      component='nav'
+      position='fixed'
+      sx={{
+        background: 'transparent',
+        backgroundColor: 'e8e8e8',
+        color: '#000000',
+        height: '5rem',
+        justifyContent: 'center',
+        // boxShadow: 'none',
+      }}
+    >
+      <Container maxWidth='lg'>
+        <Toolbar>
+          <Typography
+            variant='h4'
+            component='div'
+            sx={{
+              flexGrow: 1,
+            }}
+          >
+            Match.gg
+          </Typography>
+          <Stack direction='row' spacing={2}>
+            <Button
+              variant='text'
+              color='inherit'
+              sx={{
+                marginRight: '1rem',
+                '&:hover': {
+                  borderRadius: '0',
+                  color: 'black',
+                  borderBottom: '3px solid black',
+                },
+              }}
+            >
+              About US
+            </Button>
+            <Button
+              variant='text'
+              color='inherit'
+              sx={{
+                '&:hover': {
+                  borderRadius: '0',
+                  color: 'black',
+                  borderBottom: '3px solid black',
+                },
+              }}
+            >
+              Login / Register
+            </Button>
+          </Stack>
+        </Toolbar>
+      </Container>
+    </AppBar>
+  );
+};
+
+export default Navbar;

--- a/src/pages/Landing/LandingPage.js
+++ b/src/pages/Landing/LandingPage.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Footer from '../../components/nav/Footer';
+import Navbar from '../../components/nav/Navbar';
+import LandingSection from './LandingSection';
+
+const LandingPage = () => {
+  return (
+    <>
+      <Navbar />
+      <LandingSection />
+      <Footer />
+    </>
+  );
+};
+
+export default LandingPage;

--- a/src/pages/Landing/LandingSection.js
+++ b/src/pages/Landing/LandingSection.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Box, Container, Typography, Button } from '@mui/material';
+
+const LandingSection = () => {
+  return (
+    <>
+      <Box
+        sx={{
+          height: '100vh',
+        }}
+      >
+        <Container
+          maxWidth='lg'
+          sx={{
+            height: '95vh',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <Typography
+            variant='h1'
+            sx={{
+              color: 'black',
+              fontWeight: '600',
+            }}
+          >
+            함께 플레이할 친구가
+          </Typography>
+          <Typography
+            variant='h1'
+            sx={{
+              color: 'black',
+              fontWeight: '600',
+              marginBottom: '3vh',
+            }}
+          >
+            필요하신가요?
+          </Typography>
+          <Typography
+            variant='h4'
+            sx={{
+              color: 'grey',
+              fontWeight: '300',
+              marginBottom: '3vh',
+            }}
+          >
+            이제 모든 게임 친구는 Match.gg 에서 구하세요!
+          </Typography>
+          <Button
+            sx={{
+              backgroundColor: '#d6d6d6',
+              color: 'black',
+              width: '30rem',
+              height: '3rem',
+              fontSize: '1.5rem',
+              borderColor: 'gray',
+              borderRadius: '15px',
+            }}
+          >
+            함께할 플레이어 찾기
+          </Button>
+        </Container>
+      </Box>
+      <Box
+        sx={{
+          height: '5vh',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Typography>Test</Typography>
+      </Box>
+      <Box
+        sx={{
+          height: '50vh',
+          backgroundColor: '#e8e8e8',
+        }}
+      >
+        <Container
+          maxWidth='lg'
+          sx={{
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <Typography variant='h4'>
+            리그오브레전드, 배틀그라운, 로스트아크, 메이플스토리, 오버워치
+          </Typography>
+          <Typography variant='h4'>각각 파티원 구하려면 힘드셨죠?</Typography>
+          <Typography variant='h4'>
+            저희가 여러분의 실력, 스펙에 맞춰
+          </Typography>
+          <Typography variant='h4'>
+            최고의 플레이어를 연결해 드립니다.
+          </Typography>
+        </Container>
+      </Box>
+      <Box
+        sx={{
+          height: '150vh',
+        }}
+      ></Box>
+      <Box
+        sx={{
+          height: '50vh',
+          backgroundColor: '#e8e8e8',
+        }}
+      ></Box>
+    </>
+  );
+};
+
+export default LandingSection;


### PR DESCRIPTION

## 개요

랜딩페이지 기본 틀 추가

<br>

## 주요 변경 내역

- 네비게이션 바 (현재 투명)
- 푸터
- 섹션 (구분만 되어있는 상태)


<br>
close #9 

-
